### PR TITLE
Add 'gr_supported_version' tag to OOT object

### DIFF
--- a/ootlist/models.py
+++ b/ootlist/models.py
@@ -16,8 +16,9 @@ class Outoftreemodule(models.Model):
     copyright_owner = models.CharField(max_length=500, null=True, blank=True)
     icon = models.CharField(max_length=500, null=True, blank=True) # most urls provided by people dont even work anymore, so dont display the icon for now
     website = models.CharField(max_length=500, null=True, blank=True)
+    gr_supported_version = models.CharField(max_length=500, null=True, blank=True)
     body_text = models.TextField(max_length=50000, null=True, blank=True)
-    
+
 class Packageversion(models.Model):
     os_name = models.CharField(max_length=500)
     gr_version_string = models.CharField(max_length=500)

--- a/ootlist/tables.py
+++ b/ootlist/tables.py
@@ -8,7 +8,7 @@ class OutoftreemoduleTable(tables.Table):
     tags = tables.Column(verbose_name='Categories')
     description = tables.Column(orderable=False) # no reason to ever sort by description imo
     last_commit = tables.Column(verbose_name='Most Recent Commit')
-    
+    gr_supported_version = tables.Column(verbose_name='GNU Radio supported versions')
     ''' this used the value of the status field to color the row, but it didn't look great
     def render_status(self, value, column):
         if value == 'maintained':
@@ -21,8 +21,8 @@ class OutoftreemoduleTable(tables.Table):
             column.attrs = {'td': {}}
         return value
     '''
-            
+
     class Meta:
         model = Outoftreemodule
-        fields = ('name', 'last_commit', 'description', 'tags') # fields to display
+        fields = ('name', 'last_commit', 'description', 'tags', 'gr_supported_version') # fields to display
         attrs = {'class': 'table table-condensed'} # uses bootstrap table style

--- a/ootlist/views.py
+++ b/ootlist/views.py
@@ -139,7 +139,8 @@ def refresh(request):
                                                                     copyright_owner = ", ".join(processed_yaml.get('copyright_owner', ['None'])),
                                                                     icon = processed_yaml.get('icon', 'None'),
                                                                     website = processed_yaml.get('website', 'None'),
-                                                                    body_text = body_text)) 
+                                                                    gr_supported_version = processed_yaml.get('gr_supported_version', ''),
+                                                                    body_text = body_text))
                                 else:
                                     new_oots.append(Outoftreemodule(name = giturl.split('/')[1].replace('-','‑'), # people kept giving their stuff long titles, it worked out better to just use their github project url. also, i replace the standard hyphen with a non-line-breaking hyphen =)
                                                                     tags = 'None', 
@@ -151,7 +152,8 @@ def refresh(request):
                                                                     copyright_owner = 'None',
                                                                     icon = 'None',
                                                                     website = 'None',
-                                                                    body_text = body_text))                                                        
+                                                                    gr_supported_version = '',
+                                                                    body_text = body_text))
                             else:
                                 print('error- recipe ' + recipe + ' had a broken URL')
                                     
@@ -178,8 +180,9 @@ def refresh(request):
                                     copyright_owner = 'Sylvain Munaut <tnt@246tNt.com>',
                                     icon = 'http://people.osmocom.org/~tnt/stuff/iqbal-icon.png',
                                     website = 'None',
-                                    body_text = ' '))      
-    
+                                    gr_supported_version = 'v3.7, v3.8',
+                                    body_text = ' '))
+
     new_oots.append(Outoftreemodule(name = 'gr-fosphor'.replace('-','‑'), # people kept giving their stuff long titles, it worked out better to just use their github project url. also, i replace the standard hyphen with a non-line-breaking hyphen =)
                                     tags = ", ".join(['fft','gpu','opencl','opengl']), 
                                     description = 'GNU Radio block for RTSA-like spectrum visualization using OpenCL and OpenGL acceleration', 
@@ -190,8 +193,9 @@ def refresh(request):
                                     copyright_owner = 'Sylvain Munaut <tnt@246tNt.com>',
                                     icon = 'http://people.osmocom.org/~tnt/stuff/fosphor-icon.png',
                                     website = 'None',
-                                    body_text = ' '))  
-                                        
+                                    gr_supported_version = 'v3.7, v3.8',
+                                    body_text = ' '))
+
     # clear table
     Outoftreemodule.objects.all().delete()
     # all the new objects to db


### PR DESCRIPTION
Part of the pre-FOSDEM hackfest. Adds visualization of the supported GNU Radio versions in the OOT list in CGRAN. This is to be added manually, by each OOT maintainer, in the `MANIFEST.md` as an additional tag.

cc: @noc0lour 